### PR TITLE
Handled the case for an empty -R file

### DIFF
--- a/notify-send.sh
+++ b/notify-send.sh
@@ -179,7 +179,7 @@ while (( $# > 0 )) ; do
             ;;
         -R|--replace-file|--replace-file=*)
             [[ "$1" = --replace-file=* ]] && filename="${1#*=}" || { shift; filename="$1"; }
-            if [[ -f "$filename" ]]; then
+            if [[ -s "$filename" ]]; then
                 REPLACE_ID="$(< $filename)"
             fi
             STORE_ID="$filename"


### PR DESCRIPTION
If the file passed in to -R is empty, don't use the empty value as the $REPLACE_ID. If $REPLACE_ID is empty, dbus errors. 