### PR TITLE
Add action handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 notify-send.sh is a drop-in replacement for notify-send (from
 libnotify) with ability to update and close existing notifications.
 
-The dependencies are `bash` and `gdbus` (shipped with glib2).
+The dependencies are `bash`, `gdbus` (shipped with glib2) and `dbus-monitor` (shipped with dbus).
 
 For Arch Linux users notify-send.sh is also available in [AUR].
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ additional ones:
       -i, --icon=ICON[,ICON...]         Specifies an icon filename or stock icon to display.
       -c, --category=TYPE[,TYPE...]     Specifies the notification category.
       -h, --hint=TYPE:NAME:VALUE        Specifies basic extra data to pass. Valid types are int, double, string and byte.
+      -o, --action=NAME:ACTION           Specifies action button which should be integrated to the notification. NAME will be dispayed, ACTION is the comman to run.
       -p, --print-id                    Print the notification ID to the standard output.
       -r, --replace=ID                  Replace existing notification.
       -R, --replace-file=FILE           Store and load notification replace ID to/from this file.
@@ -58,3 +59,7 @@ option. For example, to increase volume by 5% and show the current
 volume value you can run:
 
     $ notify-send.sh --replace-file=/tmp/volumenotification "Increase Volume" "$(amixer sset Master 5%+ | awk '/[0-9]+%/ {print $2,$5}')"
+
+To add a button action on the notification you can run:
+
+    $ notify-send.sh "Subject" "Message" -o "display other notification:notify-send.sh 'new Subject' 'New Message'"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ additional ones:
       -i, --icon=ICON[,ICON...]         Specifies an icon filename or stock icon to display.
       -c, --category=TYPE[,TYPE...]     Specifies the notification category.
       -h, --hint=TYPE:NAME:VALUE        Specifies basic extra data to pass. Valid types are int, double, string and byte.
-      -o, --action=NAME:ACTION           Specifies action button which should be integrated to the notification. NAME will be dispayed, ACTION is the comman to run.
+      -o, --action=NAME:ACTION          Specifies action button which should be integrated to the notification. NAME will be dispayed, ACTION is the comman to run.
       -p, --print-id                    Print the notification ID to the standard output.
       -r, --replace=ID                  Replace existing notification.
       -R, --replace-file=FILE           Store and load notification replace ID to/from this file.
@@ -63,3 +63,7 @@ volume value you can run:
 To add a button action on the notification you can run:
 
     $ notify-send.sh "Subject" "Message" -o "display other notification:notify-send.sh 'new Subject' 'New Message'"
+    
+You can specify multiple actions:
+    
+    $ notify-send.sh "Subject" "Message" -o "display first button:notify-send.sh 'new Subject' 'New Message'" -o "display second button:notify-send.sh 'new Subject' 'New Message'"

--- a/notify-action.sh
+++ b/notify-action.sh
@@ -2,14 +2,12 @@
 
 NOTIFY_ARGS=(--session "path=/org/freedesktop/Notifications,member=ActionInvoked")
 
-# set -x
-
 dbus-monitor "${NOTIFY_ARGS[@]}" |
 while read -r line
 do 
-  IS_NOTIFY_SEND=`echo "$line" | grep "notify-send: "`
+  IS_NOTIFY_SEND=`echo "$line" | grep "notify-send.sh: "`
   if [[ -n $IS_NOTIFY_SEND ]]; then
-    COMMAND=`echo "$line" | sed -e 's/string "notify-send: \(.*\)"$/\1/'`
+    COMMAND=`echo "$line" | sed -e 's/string "notify-send.sh: \(.*\)"$/\1/'`
     bash -c "$COMMAND"
   fi
 done

--- a/notify-action.sh
+++ b/notify-action.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+NOTIFY_ARGS=(--session "path=/org/freedesktop/Notifications,member=ActionInvoked")
+
+# set -x
+
+dbus-monitor "${NOTIFY_ARGS[@]}" |
+while read -r line
+do 
+  IS_NOTIFY_SEND=`echo "$line" | grep "notify-send: "`
+  if [[ -n $IS_NOTIFY_SEND ]]; then
+    COMMAND=`echo "$line" | sed -e 's/string "notify-send: \(.*\)"$/\1/'`
+    bash -c "$COMMAND"
+  fi
+done


### PR DESCRIPTION
Hi,

Here I propose a way to handle action with notify-send.

By defining an action you add a button on the notification which will call the corresponding command when the user clicks on it.

The implementation is quite simple :
- a daemon is launch to listen on dbus events which contains a specific string
- the action is passed on dbus notification message 
- The notification server sends a dbus message when the action is triggered by the user
- the message is received by the daemon which run the given command

Currently the command to run is set on the action itself so nothing is stored.
Only one daemon is run and each time notify-send is called, it checks if the notify-action daemon is running.