### PR TITLE
Allow empty summary

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 Vyacheslav Levit <dev@vlevit.org>
 Max Weller <https://github.com/max-weller>
 bsilvereagle <https://github.com/bsilvereagle>
+nylen <https://github.com/nylen>

--- a/notify-send.sh
+++ b/notify-send.sh
@@ -37,6 +37,7 @@ APP_NAME="${0##*/}"
 REPLACE_ID=0
 URGENCY=1
 HINTS=()
+SUMMARY_SET=n
 
 help() {
     cat <<EOF
@@ -173,7 +174,12 @@ process_posargs() {
         echo "Unknown option $1"
         exit 1
     else
-        [[ -z "$SUMMARY" ]] && SUMMARY="$1" || BODY="$1"
+        if [[ "$SUMMARY_SET" = n ]]; then
+            SUMMARY="$1"
+            SUMMARY_SET=y
+        else
+            BODY="$1"
+        fi
     fi
 }
 
@@ -243,7 +249,7 @@ done
 # urgency is always set
 HINTS=("$(make_hint byte urgency "$URGENCY")" "${HINTS[@]}")
 
-if [[ -z "$SUMMARY" ]] ; then
+if [[ -z "$SUMMARY" && -z "$BODY" ]] ; then
     help
     exit 1
 else

--- a/notify-send.sh
+++ b/notify-send.sh
@@ -249,7 +249,7 @@ done
 # urgency is always set
 HINTS=("$(make_hint byte urgency "$URGENCY")" "${HINTS[@]}")
 
-if [[ -z "$SUMMARY" && -z "$BODY" ]] ; then
+if [[ "$SUMMARY_SET" = n ]] ; then
     help
     exit 1
 else


### PR DESCRIPTION
Per the [notification spec](http://www.galago-project.org/specs/notification/0.9/x161.html), the notification body can contain markup like `<b>some text</b>` but the summary cannot.

I want my notifications to look like this, with the first line in bold:

> <img src="https://user-images.githubusercontent.com/227022/41210019-990ac80c-6cf4-11e8-8415-e5444dca1c81.png" width="146">

The only way to achieve this is to leave the summary blank, which is not supported by `notify-send` (it says `No summary specified`) or `notify-send.sh` (it sends the text as the summary with an empty body, which does not work with markup).

As far as I can tell, there is no problem with supporting an empty summary.  After the changes in this PR, here is the command that generates the notification above:

```sh
$ ./notify-send.sh '' "$(echo -ne '<b>first line</b>\nsecond line\netc')" -i info
```