### PR TITLE
Fix redirection error for STORE_ID when filename has spaces

### DIFF
--- a/notify-send.sh
+++ b/notify-send.sh
@@ -117,7 +117,7 @@ notify() {
                           | parse_notification_id)
 
     if [[ -n "$STORE_ID" ]] ; then
-        echo "$NOTIFICATION_ID" > $STORE_ID
+        echo "$NOTIFICATION_ID" > "$STORE_ID"
     fi
     if [[ -n "$PRINT_ID" ]] ; then
         echo "$NOTIFICATION_ID"

--- a/notify-send.sh
+++ b/notify-send.sh
@@ -286,7 +286,7 @@ while (( $# > 0 )) ; do
         -R|--replace-file|--replace-file=*)
             [[ "$1" = --replace-file=* ]] && filename="${1#*=}" || { shift; filename="$1"; }
             if [[ -s "$filename" ]]; then
-                REPLACE_ID="$(< $filename)"
+                REPLACE_ID="$(< "$filename")"
             fi
             STORE_ID="$filename"
             ;;


### PR DESCRIPTION
If STORE_ID variable containing a filename has spaces, redirection will fail.