### PR TITLE
Mark positional args on `gdbus call` invocation

### DIFF
--- a/notify-send.sh
+++ b/notify-send.sh
@@ -112,6 +112,7 @@ notify() {
 
     NOTIFICATION_ID=$(gdbus call "${NOTIFY_ARGS[@]}"  \
                             --method org.freedesktop.Notifications.Notify \
+                            -- \
                             "$APP_NAME" "$REPLACE_ID" "$ICON" "$SUMMARY" "$BODY" \
                             "${actions}" "${hints}" "int32 $EXPIRE_TIME" \
                           | parse_notification_id)


### PR DESCRIPTION
Currently, the script consumes the `--` argument that marks the beginning of positional arguments.

That means that despite properly deliminating the positional arguments with `--`, `gdbus call` is invoked improperly.

See this usage example comparing the results of libnotify's `notify-send` against `notify-send.sh`

```
$ notify-send summary -test
Missing argument for -t

$ notify-send.sh summary -test
Unknown option -test

$ notify-send -- summary -test
# notification produced with body '-test'

$ notify-send.sh -- summary -test
Usage:
  gdbus call [OPTION…]
...

```