### PR TITLE
Remove `bc` dependency

### DIFF
--- a/notify-send.sh
+++ b/notify-send.sh
@@ -124,8 +124,7 @@ notify() {
     fi
 
     if [[ -n "$FORCE_EXPIRE" ]] ; then
-        type bc &> /dev/null || { echo "bc command not found. Please install bc package."; exit 1; }
-        SLEEP_TIME="$(bc <<< "scale=3; $EXPIRE_TIME / 1000")"
+        SLEEP_TIME="$( printf %f "${EXPIRE_TIME}e-3" )"
         ( sleep "$SLEEP_TIME" ; notify_close "$NOTIFICATION_ID" ) &
     fi
 


### PR DESCRIPTION
exploit printf's ability to format floating-point numbers to avoid depending on bc