### PR TITLE
Fixed locale issue inside sleep command

### DIFF
--- a/notify-send.sh
+++ b/notify-send.sh
@@ -125,7 +125,7 @@ notify() {
     fi
 
     if [[ -n "$FORCE_EXPIRE" ]] ; then
-        SLEEP_TIME="$( printf %f "${EXPIRE_TIME}e-3" )"
+        SLEEP_TIME="$( LC_NUMERIC='en_US.UTF-8' printf %f "${EXPIRE_TIME}e-3" )"
         ( sleep "$SLEEP_TIME" ; notify_close "$NOTIFICATION_ID" ) &
     fi
 

--- a/notify-send.sh
+++ b/notify-send.sh
@@ -125,7 +125,7 @@ notify() {
     fi
 
     if [[ -n "$FORCE_EXPIRE" ]] ; then
-        SLEEP_TIME="$( LC_NUMERIC='en_US.UTF-8' printf %f "${EXPIRE_TIME}e-3" )"
+        SLEEP_TIME="$( LC_NUMERIC=C printf %f "${EXPIRE_TIME}e-3" )"
         ( sleep "$SLEEP_TIME" ; notify_close "$NOTIFICATION_ID" ) &
     fi
 


### PR DESCRIPTION
# Problem
I'm from Italy, here we write float numbers in a different way: we use commas to divide the integer and decimal parts, like 5,04 instead of the standard 5.04.

The `sleep` command won't work when given numbers in this format and will raise an error like this:
```console
$ sleep 5,04
sleep: invalid time interval ‘5,04’
Try 'sleep --help' for more information.
$ 
```

Same will be raised when calling `./notify-send.sh -t 5040 -f Test`, because `sleep 5,04` will be internally called. That number is computed using the printf command, which gives different output with different locales.

# My solution
I added a locale change within the internal call to the `printf` command:
`LC_NUMERIC='en_US.UTF-8' printf %f "${EXPIRE_TIME}e-3`